### PR TITLE
Setting - Track minimal match history

### DIFF
--- a/src/apollo/schema.ts
+++ b/src/apollo/schema.ts
@@ -130,6 +130,7 @@ export const StashPluginUserSettingsParsed = z.object({
   arrowKeys: z.boolean().optional(),
   boardWidth: z.number().optional(),
   imageQuality: z.literal(["original", "thumbnail"]).optional(),
+  minimalHistory: z.boolean().optional(),
   progressMaxRows: z.number().optional(),
   readOnly: z.boolean().optional(),
 });

--- a/src/components/RankingList/RankingList.stories.tsx
+++ b/src/components/RankingList/RankingList.stories.tsx
@@ -8,7 +8,14 @@ const stashPerformers = allPerformers.data.findPerformers.performers.map(p => ({
         id: +p.id
     }))
 
-const rankedPerformers = formatPerformersToRanked(stashPerformers)
+const rankedPerformers = formatPerformersToRanked(stashPerformers).map(p => ({
+  ...p,
+  recentOpponent: {
+    ...p.recentOpponent,
+    // Add static name to fulfil accessibility report.
+    name: "Opponent name"
+  }
+}))
 
 const meta = {
   title: "Components/RankingList",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,10 +23,12 @@ export const DEFAULT_ALLOW_ARROW_KEYS = true;
 export const DEFAULT_BOARD_WIDTH = 1100;
 export const DEFAULT_IMAGE_QUALITY = "thumbnail";
 export const DEFAULT_MAX_PROGRESS_BOARD_ROWS = 5;
+export const DEFAULT_MINIMAL_HISTORY = false;
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   arrowKeys: DEFAULT_ALLOW_ARROW_KEYS,
   boardWidth: DEFAULT_BOARD_WIDTH,
   imageQuality: DEFAULT_IMAGE_QUALITY,
+  minimalHistory: DEFAULT_MINIMAL_HISTORY,
   progressMaxRows: DEFAULT_MAX_PROGRESS_BOARD_ROWS,
 };

--- a/src/helpers/gameplay.ts
+++ b/src/helpers/gameplay.ts
@@ -69,3 +69,15 @@ export const formatPerformersToRanked = (
 
   return rankedPerformers;
 };
+
+/** Get the result of a match as it relates to the given performer. */
+export const getPerformerOutcomeFromRecord = (
+  id: StashPerformer["id"],
+  match: GlickoMatchResult
+): 0 | 1 | 0.5 => {
+  // If the performer is player 1, return the result.
+  if (id === +match[0]) return match[2];
+
+  // If the performer is player 2, translate the result as it relates to them
+  return match[2] === 0 ? 1 : match[2] === 1 ? 0 : 0.5;
+};

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -11,6 +11,7 @@ import WipePerformerData, {
   WipePerformerDataModal,
 } from "./options/WipePerformerData";
 import styles from "./Settings.module.scss";
+import MinimalHistory from "./options/MinimalHistory";
 
 interface SettingsPageProps extends PageProps {
   /** The user's game settings. */
@@ -94,8 +95,11 @@ const SettingsPage: React.FC<SettingsPageProps> = (props) => {
         >
           <h1>Settings</h1>
           <div className="row">
-            <div className="col-12 mt-3">
+            <div className="col-12 col-lg-6 mt-3">
               <ReadOnlyMode enabled={props.settings.readOnly} />
+            </div>
+            <div className="col-12 col-lg-6 mt-3">
+              <MinimalHistory enabled={props.settings.minimalHistory} />
             </div>
             <div className="col-12 col-lg-6 mt-3">
               <ImageQuality imageQuality={props.settings.imageQuality} />
@@ -180,6 +184,9 @@ const convertFormDataToUserSettings = (data: FormData): UserSettings => {
   // Read-only mode
   const readOnly = !!formKeys.find((k) => k === "read-only");
 
+  // Minimal match history
+  const minimalHistory = !!formKeys.find((k) => k === "minimal-history");
+
   // Image quality
   const imageQuality =
     formJson["image-quality"] === "original" ? "original" : "thumbnail";
@@ -197,6 +204,7 @@ const convertFormDataToUserSettings = (data: FormData): UserSettings => {
     arrowKeys,
     boardWidth,
     imageQuality,
+    minimalHistory,
     progressMaxRows,
     readOnly,
   };
@@ -207,6 +215,7 @@ const convertFormDataToUserSettings = (data: FormData): UserSettings => {
 /** Compares two sets of user settings for equality. */
 const compareSettings = (setA: UserSettings, setB: UserSettings): boolean => {
   if (setA.readOnly !== setB.readOnly) return false;
+  if (setA.minimalHistory !== setB.minimalHistory) return false;
   if (setA.imageQuality !== setB.imageQuality) return false;
   if (setA.arrowKeys !== setB.arrowKeys) return false;
   if (setA.progressMaxRows !== setB.progressMaxRows) return false;

--- a/src/pages/Settings/options/MinimalHistory.tsx
+++ b/src/pages/Settings/options/MinimalHistory.tsx
@@ -16,7 +16,7 @@ const MinimalHistory: React.FC<MinimalHistoryProps> = (props) => {
               ? DEFAULT_MINIMAL_HISTORY
               : props.enabled,
           id: "minimalHistory",
-          label: "Enable minimal history",
+          label: "Enable minimal match history",
           labelAsHeading: true,
           name: "minimal-history",
         },

--- a/src/pages/Settings/options/MinimalHistory.tsx
+++ b/src/pages/Settings/options/MinimalHistory.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import CheckboxGroup from "@/components/forms/CheckboxGroup/CheckboxGroup";
+import { DEFAULT_MINIMAL_HISTORY } from "@/constants";
+
+interface MinimalHistoryProps {
+  enabled: UserSettings["minimalHistory"];
+}
+
+const MinimalHistory: React.FC<MinimalHistoryProps> = (props) => {
+  return (
+    <CheckboxGroup
+      checkboxes={[
+        {
+          isChecked:
+            props.enabled === undefined
+              ? DEFAULT_MINIMAL_HISTORY
+              : props.enabled,
+          id: "minimalHistory",
+          label: "Enable minimal history",
+          labelAsHeading: true,
+          name: "minimal-history",
+        },
+      ]}
+    >
+      <small>
+        <p className="mt-2">
+          When enabled, only the data for each performer's most recent match and
+          two most recent sessions will be saved to their profile, as opposed to
+          saving data for all matches and sessions. This may impact future
+          planned features, but reduce loading times and the size of performers'
+          custom data.
+        </p>
+      </small>
+    </CheckboxGroup>
+  );
+};
+
+export default MinimalHistory;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -196,6 +196,10 @@ interface UserSettings {
   boardWidth?: number;
   /** The quality of the image taken from Stash. */
   imageQuality?: "original" | "thumbnail";
+  /** When enabled, only a performer's most recent match will be saved to
+   * `glicko_match_history` and two most recent sessions will be saved to
+   * `glicko_session_history`. */
+  minimalHistory?: boolean;
   /** The maximum number of rows to display in the progress board shown
    * underneath the match board. */
   progressMaxRows?: number;


### PR DESCRIPTION
Added a user setting to track only a minimal amount of data in performer custom fields.